### PR TITLE
fix(relative-paths): fix to allow url rebasing to use relative paths

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -30,16 +30,16 @@ module.exports = function bundle(loads, opts) {
       root = (loader.rootURL || loader.baseURL).substring('file:'.length);
 
     return new CleanCSS({
-      target: this.separateCSS ? opts.outFile : '.',
+      target: loader.separateCSS ? opts.outFile : '.',
       relativeTo: path.dirname(cssFile),
-      root: root
+      root: loader.separateCSS ? undefined : root
     }).minify(load.source).styles;
   }).reduce(function(s1, s2) {
     return s1 + s2;
   }, '');
 
   // write a separate CSS file if necessary
-  if (this.separateCSS) {
+  if (loader.separateCSS) {
     fs.writeFileSync(opts.outFile.replace(/\.js$/, '.css'), cssOutput);
     return stubDefines;
   }


### PR DESCRIPTION
- this.separateCSS was undefined due to function scope
- setting 'root' option takes precedence over 'target' so clean-css always used absolute paths

From clean-css:

```
How to rebase relative image URLs

Clean-css will handle it automatically for you (since version 1.1) in the following cases:

When using the CLI:
Use an output path via -o/--output to rebase URLs as relative to the output file.
Use a root path via -r/--root to rebase URLs as absolute from the given root path.
If you specify both then -r/--root takes precendence.
When using clean-css as a library:
Use a combination of relativeTo and target options for relative rebase (same as 1 in CLI).
Use a combination of relativeTo and root options for absolute rebase (same as 2 in CLI).
root takes precendence over target as in CLI.
```

So the act of setting 'root' causes clean-css to always use absolute urls.

This change means that relative urls are used when separateCSS is set and absolute paths will be used when it is not set. Although I wonder if the correct thing to do is actually to only use absolute paths when 'rootURL' is set?