### PR TITLE
Propagate CSS load failures.

### DIFF
--- a/css.js
+++ b/css.js
@@ -29,11 +29,14 @@ if (typeof window !== 'undefined') {
       var timeout = setTimeout(function() {
         reject('Unable to load CSS');
       }, waitSeconds * 1000);
-      var _callback = function() {
+      var _callback = function(error) {
         clearTimeout(timeout);
-        link.onload = noop;
+        link.onload = link.onerror = noop;
         setTimeout(function() {
-          resolve('');
+          if (error)
+            reject(error);
+          else
+            resolve('');
         }, 7);
       }
       var link = document.createElement('link');
@@ -41,10 +44,16 @@ if (typeof window !== 'undefined') {
       link.rel = 'stylesheet';
       link.href = url;
   
-      if (!isWebkit)
-        link.onload = _callback;
-      else
+      if (!isWebkit) {
+        link.onload = function() {
+          _callback();
+        }
+        link.onerror = function(event) {
+          _callback(event.error);
+        }
+      } else {
         webkitLoadCheck(link, _callback);
+      }
   
       head.appendChild(link);
     });


### PR DESCRIPTION
This will aid in debugging problems (fail immediately with the real
error instead of hitting the 100 second timeout). I didn't touch the
separate webkit path which I don't understand well enough to make a
similar fix.