### PR TITLE
IE8 fix

### DIFF
--- a/css.js
+++ b/css.js
@@ -72,7 +72,7 @@ else {
     var loader = this;
     if (loader.buildCSS === false)
       return '';
-    return loader.import('./css-builder', { name: module.id }).then(function(builder) {
+    return loader['import']('./css-builder', { name: module.id }).then(function(builder) {
       return builder.call(loader, loads, opts);
     });
   };


### PR DESCRIPTION
IE8 doesn't like when property names are js reserved words...

A very small fix, that ease my pain supporting IE8 ;-)