### PR TITLE
Provide another loading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ CSS loading plugin
 Basic Use
 ---
 
+CSS in your public directory:
 ```javascript
 import './style.css!'
 ```
+
+CSS from a package:
+```javascript
+import 'bootstrap/css/bootstrap.css!'
+```
+
 
 Currently CSS bundling is only supported in jspm, please post an issue if you would like support outside of jspm.
 


### PR DESCRIPTION
It was unclear to me how to include code from packages. This README modification makes usage more clear.