### PR TITLE
feat(hot-reload): add support for hot-reloading

### DIFF
--- a/css.js
+++ b/css.js
@@ -39,10 +39,24 @@ if (typeof window !== 'undefined') {
             resolve('');
         }, 7);
       };
-      var link = document.createElement('link');
-      link.type = 'text/css';
-      link.rel = 'stylesheet';
-      link.href = url;
+      
+      var present = false;
+      var link = undefined;
+      
+      for (var i = 0; i < links.length; i++) {
+        if (links[i].href.split('?')[0] === url) {
+          link = links[i];
+          present = true;
+          break;
+        }
+      }
+      
+      if (!present) {
+        link = document.createElement('link');
+        link.type = 'text/css';
+        link.rel = 'stylesheet';
+      }
+   
       if (!isWebkit) {
         link.onload = function() {
           _callback();
@@ -50,10 +64,17 @@ if (typeof window !== 'undefined') {
       } else {
         webkitLoadCheck(link, _callback);
       }
+      
       link.onerror = function(event) {
         _callback(event.error || new Error('Error loading CSS file.'));
       };
-      head.appendChild(link);
+
+      if (present)        
+         link.href = url + '?' + new Date().getTime();
+      else
+         link.href = url; // back-compatibility
+      
+      if (!present) head.appendChild(link);
     });
   };
 


### PR DESCRIPTION
This adds support for hot-reloading css when using [systemjs-hot-reloader](https://github.com/capaj/systemjs-hot-reloader) in the browser. It forces the link tags to update by adding a query parameter to the source url. For back-compatibility when the link tag is first created it is assigned the url without a query parameter.

For an example setup see [here](https://github.com/frankwallis/plugin-typescript/tree/master/example/react), feedback welcome, thanks
