### PR TITLE
css map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,54 @@ Currently CSS bundling is only supported in jspm, please post an issue if you wo
 
 If not using jspm, set `System.buildCSS = false` to disable the builds.
 
+Advanced Configuration
+---
+
+While this plugin don't have plugin functionality yet to run csscomb, 
+autoprefixer, less, scss, postcss etc. you will still be able to do that 
+on backend side.
+
+You can override css location with `System.cssOptions.map` property.
+
+Example:
+
+```javascript
+SystemJS.config({
+  paths: {
+    "app/": "src/"
+  },
+  cssOptions: {
+    "map": {
+      "src/*.less": ".tmp/src/*.css"
+    }
+  }
+});
+```
+
+On backend side something like grunt, gulp must watch files for changes and
+rebuild them in the way you need. BrowserSync could emit changes and do css hot
+reload for you.
+
+Other MAP examples:
+
+```javascript
+{
+  "src/": ".tmp/src/",
+  "src": ".tmp/src",
+  "src/*.less": ".tmp/src/*.css",
+  "src/*.css": ".tmp/src/*.css",
+}
+```
+
+This plugin performs weighted mapping so if you have multiple matching map 
+conditions then the last one with highest weight will be used for location
+remap.
+
+Weight measured by amount of characters matched between source location and 
+map condition excluding wildcard characters.
+
+Only one wildcard character is allowed to be used in map condition. 
+
 Modular CSS Concepts
 ---
 

--- a/css.js
+++ b/css.js
@@ -72,7 +72,7 @@ if (typeof window !== 'undefined') {
         head.appendChild(link);
     })
     // Remove the old link regardless of loading outcome
-    .then(function(result){ 
+    .then(function(result){
       forEach(existingLinks, function(link){link.parentElement.removeChild(link);})
       return result;
     }, function(err){
@@ -81,6 +81,12 @@ if (typeof window !== 'undefined') {
     })
   };
 
+  exports.locate = function(load, opts) {
+    return System['import']('./path-resolver.js', module.id)
+      .then(function(resolvePath) {
+        return resolvePath(load.address, this);
+      }.bind(this));
+  };
   exports.fetch = function(load) {
     // dont reload styles loaded in the head
     var links = findExistingCSS(load.address);
@@ -94,7 +100,7 @@ else {
   function getBuilder(loader) {
     if (builderPromise)
       return builderPromise;
-    
+
     return builderPromise = System['import']('./css-plugin-base.js', module.id)
     .then(function(CSSPluginBase) {
       return new CSSPluginBase(function compile(source, address) {
@@ -109,6 +115,12 @@ else {
   }
 
   exports.cssPlugin = true;
+  exports.locate = function(load, opts) {
+    return System['import']('./path-resolver.js', module.id)
+      .then(function(resolvePath) {
+        return resolvePath(load.address, this);
+      }.bind(this));
+  };
   exports.translate = function(load, opts) {
     var loader = this;
     return getBuilder(loader).then(function(builder) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemjs-plugin-css",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "main": "css",
   "registry": "jspm",
   "scripts": {

--- a/path-resolver.js
+++ b/path-resolver.js
@@ -1,0 +1,138 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position){
+    position = position || 0;
+    return this.substr(position, searchString.length) === searchString;
+  };
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+    var subjectString = this.toString();
+    if (typeof position !== 'number' 
+      || !isFinite(position) 
+      || Math.floor(position) !== position 
+      || position > subjectString.length
+    ) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.indexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+if (!Object.keys) {
+  Object.keys = (function() {
+    'use strict';
+    var hasOwnProperty = Object.prototype.hasOwnProperty,
+        hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
+        dontEnums = [
+          'toString',
+          'toLocaleString',
+          'valueOf',
+          'hasOwnProperty',
+          'isPrototypeOf',
+          'propertyIsEnumerable',
+          'constructor'
+        ],
+        dontEnumsLength = dontEnums.length;
+
+    return function(obj) {
+      if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
+        throw new TypeError('Object.keys called on non-object');
+      }
+
+      var result = [], prop, i;
+
+      for (prop in obj) {
+        if (hasOwnProperty.call(obj, prop)) {
+          result.push(prop);
+        }
+      }
+
+      if (hasDontEnumBug) {
+        for (i = 0; i < dontEnumsLength; i++) {
+          if (hasOwnProperty.call(obj, dontEnums[i])) {
+            result.push(dontEnums[i]);
+          }
+        }
+      }
+      return result;
+    };
+  }());
+}
+
+function tryResolvePath(path, mapCondition, mapRule) {
+  var matchLength = 0;
+  var resolvedPath = null;
+
+  if (mapCondition.indexOf('*') !== -1) {
+    var parts = mapCondition.split('*');
+
+    if (parts.length !== 2) {
+      throw new TypeError('Only one wildcard in a path map condition is permitted');
+    }
+
+    if (path.startsWith(parts[0]) && path.endsWith(parts[1])) {
+      matchLength = mapCondition.length - 1; // minus asterisk character
+
+      if (mapRule.indexOf('*') === -1) {
+        throw new TypeError('Path map rule must have wildcard if path map codition have it');
+      }
+
+      if (mapRule.indexOf('*') !== mapRule.lastIndexOf('*')) {
+        throw new TypeError('Only one wildcard in a path map rule is permitted');
+      }
+
+      resolvedPath = mapRule.replace(
+        '*',
+        path.substr(parts[0].length, path.length - matchLength)
+      );
+    }
+  } else if (path.startsWith(mapCondition)) {
+    matchLength = mapCondition.length;
+    resolvedPath = mapRule
+      + path.substr(mapCondition.length, path.length - matchLength);
+  } else if (mapCondition.replace(/\/$/, '') === path) {
+    matchLength = mapCondition.length - 1;
+    resolvedPath = mapRule.replace(/\/$/, '');
+  }
+
+  if (!resolvedPath) {
+    return;
+  }
+
+  return {
+    weight: matchLength,
+    path: resolvedPath
+  };
+}
+
+function resolvePath(path, loader) {
+  var map = (loader.cssOptions || {}).map;
+  var baseURL = loader.baseURL;
+
+  if (!map) {
+    return path;
+  }
+
+  var resolution = Object.keys(map)
+    .reduce(function (result, condition) {
+      var resolution = tryResolvePath(path, baseURL + condition, baseURL + map[condition]);
+      if (resolution && (!result || resolution.weight >= result.weight)) {
+        return resolution;
+      }
+      return result;
+    }, undefined);
+
+  if (resolution) {
+    return resolution.path;
+  }
+
+  return path;
+}
+
+module.exports = resolvePath;


### PR DESCRIPTION
Hello. I would like to propose a micro fix which will allow to map css-like files with wildcards. That will allow to use css pre/post processing on backend side for css-like files while SystemJS and builder will not know about that. That could be a good temporary solution until new plugin-css with modules for less, scss, autoprefixer etc. will be implemented. Thank you.

PS: May be we could move all css related options into `cssOptions` config property.