### PR TITLE
Convert back slashes to forward slashes in import statement.

### DIFF
--- a/css-plugin-base-builder.js
+++ b/css-plugin-base-builder.js
@@ -143,7 +143,7 @@ exports.bundle = function(loads, compileOpts, outputOpts) {
     }));
 
   return postcss(postCssPlugins)
-  .process(Object.keys(inputFiles).map(name => '@import "' + name + '";').join('\n'), {
+  .process(Object.keys(inputFiles).map(name => '@import "' + name.replace(/\\/g, '/') + '";').join('\n'), {
     from: path.join(baseURLPath, '__.css'),
     to: cwd + path.sep + '__.css',
     map: {


### PR DESCRIPTION
Usually an import of css is replaced with the css content, however sometimes it results in an @import statement.
Could not produce an example that generates an @import statement. In a current project of mine this happens to some css files imported from a jspm package. Not sure what triggers it (size/other references/location).
Therefor, no unit test was added