### PR TITLE
Fixes #131, detect URL reference referring to id reference and avoid …

### DIFF
--- a/css-plugin-base-builder.js
+++ b/css-plugin-base-builder.js
@@ -122,7 +122,7 @@ exports.bundle = function(loads, compileOpts, outputOpts) {
     }
   }), atUrl({
     url: function(fileName, decl, from, dirname, to, options, result) {
-      if (absUrl(fileName))
+      if (absUrl(fileName) || fileName.match(/^%23/))
         return fileName;
 
       // dirname may be renormalized to cwd


### PR DESCRIPTION
…modification in this case

IF an url reference contains a leading # character, it is an id reference and this should not be modified.