### PR TITLE
Fix prepending of loader.browserRootURL to root-relative url

### DIFF
--- a/css-plugin-base-builder.js
+++ b/css-plugin-base-builder.js
@@ -122,7 +122,7 @@ exports.bundle = function(loads, compileOpts, outputOpts) {
     }
   }), atUrl({
     url: function(fileName, decl, from, dirname, to, options, result) {
-      if (absUrl(fileName) || fileName.match(/^%23/))
+      if ((absUrl(fileName) && fileName.charAt(0) !== '/') || fileName.match(/^%23/))
         return fileName;
 
       // dirname may be renormalized to cwd
@@ -130,7 +130,11 @@ exports.bundle = function(loads, compileOpts, outputOpts) {
         dirname = path.resolve(baseURLPath, dirname.substr(cwd.length + 1));
 
       if (loader.rootURL)
-        return (loader.browserRootURL || '/') + path.relative(loader.rootURL, path.join(dirname, fileName)).replace(/\\/g, '/');
+        if (fileName.charAt(0) === '/') {
+          return (loader.browserRootURL || '/') + fileName.replace(/\\/g, '/').replace(/\//, '');
+        } else {
+          return (loader.browserRootURL || '/') + path.relative(loader.rootURL, path.join(dirname, fileName)).replace(/\\/g, '/');
+        }
       else
         return path.relative(baseURLPath, path.join(dirname, fileName)).replace(/\\/g, '/');
     }


### PR DESCRIPTION
Previously `background-image: url(/foo.png)` would be left as-is despite `loader.browerRootURL` being configured, causing browsers to fail to load it when the stylesheet is being loaded as an object url.